### PR TITLE
Update mongoose prevent security vulnerabilities

### DIFF
--- a/flote/src/components/molecules/Footer/Footer.tsx
+++ b/flote/src/components/molecules/Footer/Footer.tsx
@@ -7,7 +7,7 @@ type Props = {
 export default function Footer({ className }: Props) {
   return (
     <div className={`py-4 bg-slate-800 text-white waveAnimation ${className}`}>
-      <Logo className="text-2xl"/>
+      {/* <Logo className="text-2xl"/> */}
     </div>
   );
 }

--- a/flote/src/components/molecules/tables/RegattaTable.tsx
+++ b/flote/src/components/molecules/tables/RegattaTable.tsx
@@ -22,7 +22,7 @@ export default function RegattaTable({ searchQuery }: Props) {
   const rows: SearchTableRow[] = regattas.map((e) => {
     return {
       id: e._id!,
-      date: new Date().toLocaleString(), // TODO
+      date: new Date().toLocaleDateString(), //e.date.toISOString(), // TODO: instead of current date, get date in regatta object
       name: e.name,
       action: <OpenExternalLinkButton />,
     };

--- a/flote/src/models/Regatta.tsx
+++ b/flote/src/models/Regatta.tsx
@@ -1,7 +1,6 @@
 export type Regatta = {
   _id?: string;
   name: string;
-  //date: Date;
   adminId: string;
   timekeeperIds: string[];
   boatIds: string[];

--- a/flote/src/models/Regatta.tsx
+++ b/flote/src/models/Regatta.tsx
@@ -1,6 +1,7 @@
 export type Regatta = {
   _id?: string;
   name: string;
+  //date: Date;
   adminId: string;
   timekeeperIds: string[];
   boatIds: string[];

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "express": "^4.21.1",
         "express-openid-connect": "^2.17.1",
         "mongodb": "^6.10.0",
-        "mongoose": "^8.7.2",
+        "mongoose": ">=8.8.3",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "express": "^4.21.1",
     "express-openid-connect": "^2.17.1",
     "mongodb": "^6.10.0",
-    "mongoose": "^8.7.2",
+    "mongoose": ">=8.8.3",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Security fix to prevent search injection attacks.
Updated package and package-lock.json to use a more current version of mongoose that prevents this security vulnerability.
Updated to mongoose version 8.8.3 or higher.

![image](https://github.com/user-attachments/assets/4b415a10-5884-4982-8282-efc01c5a5580)
